### PR TITLE
:bug: fix: removes omitempty from nodeadm template

### DIFF
--- a/bootstrap/eks/api/v1beta2/nodeadmconfigtemplate_type.go
+++ b/bootstrap/eks/api/v1beta2/nodeadmconfigtemplate_type.go
@@ -27,6 +27,11 @@ type NodeadmConfigTemplateSpec struct {
 
 // NodeadmConfigTemplateResource defines the Template structure.
 type NodeadmConfigTemplateResource struct {
+	// Spec represents the NodeadmConfig each object created from the template will become.
+	// We are setting nullable to avoid this issue:
+	// https://github.com/kubernetes/kubernetes/issues/117447#issuecomment-2127733969
+	// where we cannot remove all fields with an SSA patch if they were previously set.
+	// +nullable
 	Spec NodeadmConfigSpec `json:"spec,omitempty"`
 }
 

--- a/bootstrap/eks/controllers/nodeadmconfig_controller_reconciler_test.go
+++ b/bootstrap/eks/controllers/nodeadmconfig_controller_reconciler_test.go
@@ -39,6 +39,7 @@ func TestNodeadmConfigReconciler_CreateSecret(t *testing.T) {
 	endpoint := clusterv1.APIEndpoint{Host: "https://9.9.9.9", Port: 6443}
 	amcp.Spec.ControlPlaneEndpoint = endpoint
 	cluster := newCluster(amcp.Name)
+	cluster.Spec.ControlPlaneEndpoint = endpoint
 	newStatus := cluster.Status
 	amcpStatus := amcp.Status
 	g.Expect(testEnv.Client.Create(ctx, amcp)).To(Succeed())
@@ -77,6 +78,7 @@ func TestNodeadmConfigReconciler_UpdateSecret_ForMachinePool(t *testing.T) {
 	endpoint := clusterv1.APIEndpoint{Host: "https://9.9.9.9", Port: 6443}
 	amcp.Spec.ControlPlaneEndpoint = endpoint
 	cluster := newCluster(amcp.Name)
+	cluster.Spec.ControlPlaneEndpoint = endpoint
 	newStatus := cluster.Status
 	amcpStatus := amcp.Status
 	g.Expect(testEnv.Client.Create(ctx, amcp)).To(Succeed())
@@ -137,6 +139,7 @@ func TestNodeadmConfigReconciler_ResolvesSecretFileReference(t *testing.T) {
 	endpoint := clusterv1.APIEndpoint{Host: "https://9.9.9.9", Port: 6443}
 	amcp.Spec.ControlPlaneEndpoint = endpoint
 	cluster := newCluster(amcp.Name)
+	cluster.Spec.ControlPlaneEndpoint = endpoint
 	newStatus := cluster.Status
 	amcpStatus := amcp.Status
 	g.Expect(testEnv.Client.Create(ctx, amcp)).To(Succeed())

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_nodeadmconfigs.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_nodeadmconfigs.yaml
@@ -39,12 +39,6 @@ spec:
           spec:
             description: NodeadmConfigSpec defines the desired state of NodeadmConfig.
             properties:
-              PreNodeadmCommands:
-                description: PreNodeadmCommands specifies extra commands to run before
-                  bootstrapping nodes.
-                items:
-                  type: string
-                type: array
               containerd:
                 description: Containerd contains options for containerd.
                 properties:
@@ -233,6 +227,12 @@ spec:
                       type: string
                     type: array
                 type: object
+              preNodeadmCommands:
+                description: PreNodeadmCommands specifies extra commands to run before
+                  bootstrapping nodes.
+                items:
+                  type: string
+                type: array
               users:
                 description: Users specifies extra users to add.
                 items:

--- a/config/crd/bases/bootstrap.cluster.x-k8s.io_nodeadmconfigtemplates.yaml
+++ b/config/crd/bases/bootstrap.cluster.x-k8s.io_nodeadmconfigtemplates.yaml
@@ -49,14 +49,13 @@ spec:
                 description: NodeadmConfigTemplateResource defines the Template structure.
                 properties:
                   spec:
-                    description: NodeadmConfigSpec defines the desired state of NodeadmConfig.
+                    description: |-
+                      Spec represents the NodeadmConfig each object created from the template will become.
+                      We are setting nullable to avoid this issue:
+                      https://github.com/kubernetes/kubernetes/issues/117447#issuecomment-2127733969
+                      where we cannot remove all fields with an SSA patch if they were previously set.
+                    nullable: true
                     properties:
-                      PreNodeadmCommands:
-                        description: PreNodeadmCommands specifies extra commands to
-                          run before bootstrapping nodes.
-                        items:
-                          type: string
-                        type: array
                       containerd:
                         description: Containerd contains options for containerd.
                         properties:
@@ -252,6 +251,12 @@ spec:
                               type: string
                             type: array
                         type: object
+                      preNodeadmCommands:
+                        description: PreNodeadmCommands specifies extra commands to
+                          run before bootstrapping nodes.
+                        items:
+                          type: string
+                        type: array
                       users:
                         description: Users specifies extra users to add.
                         items:


### PR DESCRIPTION
<!-- Thanks for this PR! If this is your first PR please read the [contributing guide](../CONTRIBUTING.md) -->
<!-- If this PR is still work-in-progress and is being open for visibility please prefix the title with `WIP:` -->

**What type of PR is this?**
/kind bug

<!--
Add one of the following kinds:
/kind feature
/kind bug
/kind api-change
/kind cleanup
/kind deprecation
/kind design
/kind documentation
/kind failing-test
/kind flake
/kind regression
/kind support
-->

**What this PR does / why we need it**:

If a user is using `NodeadmConfigTemplate` with `ClusterClass` We run into a bug where SSA fails if a user is removing all fields of the `NodeadmConfigTemplate.Spec.Template.Spec`.  SSA treats this as a null object. Therefore, we are changing the property field to `nullable` to avoid this issue. 

See https://github.com/kubernetes/kubernetes/issues/117447#issuecomment-2127733969. 


<!-- Enter a description of the change and why this change is needed -->

**Which issue(s) this PR fixes** *(optional, in `fixes #<issue number>(, fixes #<issue_number>, ...)` format, will close the issue(s) when PR gets merged)*:
Fixes #

**Special notes for your reviewer**:

**Checklist**:
<!-- Put an "X" character inside the brackets of each completed task. Some may be optional depending on the PR in which case these can be deleted 

 Please add an icon to the title of this PR, the icon will be either ⚠️ (:warning:, major or breaking changes), ✨ (:sparkles:, feature additions), 🐛 (:bug:, patch and bugfixes), 📖 (:book:, documentation or proposals), or 🌱 (:seedling:, minor or other) 
-->

- [ ] squashed commits
- [ ] includes documentation
- [ ] includes emoji in title 
- [ ] adds unit tests
- [ ] adds or updates e2e tests

**Release note**:
<!--  Write your release note:
1. Enter your extended release note in the below block. If the PR requires additional action from users switching to the new release, include the string "action required".
2. If no release note is required, just write "NONE".
-->
```release-note

```
